### PR TITLE
Use the correct variant in the top-level example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.1 - 3/22/24
+
+### Changed
+- The top-level example now uses `Semantics::Relaxed` instead of `Semantics::Coupled`
+
 ## 1.0.0 - 3/21/24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptr_cell"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Nikolay Levkovsky <nik@nous.so>"]
 edition = "2021"
 description = "Thread-safe cell based on atomic pointers to externally stored data"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ fn main() {
     const VALUES: [u8; 11] = [47, 12, 88, 45, 67, 34, 78, 90, 11, 77, 33];
 
     // Construct a cell to hold the current maximum value
-    let cell = ptr_cell::PtrCell::new(None, ptr_cell::Semantics::Coupled);
+    let cell = ptr_cell::PtrCell::new(None, ptr_cell::Semantics::Relaxed);
     let maximum = std::sync::Arc::new(cell);
 
     // Slice the array in two

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //!     const VALUES: [u8; 11] = [47, 12, 88, 45, 67, 34, 78, 90, 11, 77, 33];
 //!
 //!     // Construct a cell to hold the current maximum value
-//!     let cell = ptr_cell::PtrCell::new(None, ptr_cell::Semantics::Coupled);
+//!     let cell = ptr_cell::PtrCell::new(None, ptr_cell::Semantics::Relaxed);
 //!     let maximum = std::sync::Arc::new(cell);
 //!
 //!     // Slice the array in two


### PR DESCRIPTION
The example currently uses `Semantics::Coupled`, which is frequently selected as the default. However, this specific algorithm is order-agnostic (able to correctly operate with the relaxed ordering). So, the semantics are needlessly restrictive. This updates the variant to `Semantics::Relaxed`