### PR TITLE
Use the correct heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.0 - 3/24/24
 
-## Changed
+### Changed
 - The library now links against `core` and `alloc` instead of `std`
 
 ## 1.1.0 - 3/23/24


### PR DESCRIPTION
The "Changed" section for the recent update in [CHANGELOG.md][1] uses the ## heading instead of ###. This branch fixes this

[1]: CHANGELOG.md