### PR TITLE
Make the Debug implementation less restrictive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.1 - 3/25/24
+
+### Fixed
+- Removed the unnecessary `T: Debug` bound from the `PtrCell`'s `Debug` implementation
+
 ## 1.2.0 - 3/24/24
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ptr_cell"
-version = "1.2.0"
+version = "1.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptr_cell"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Nikolay Levkovsky <nik@nous.so>"]
 edition = "2021"
 description = "Thread-safe cell based on atomic pointers to externally stored data"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
-use core::sync::atomic::Ordering;
+use core::{fmt::Debug, sync::atomic::Ordering};
 
 // As far as I can tell, accessing the cell's value is only safe when you have exclusive access to
 // the pointer. In other words, either after replacing the pointer, or when working with a &mut or
@@ -156,7 +156,6 @@ use core::sync::atomic::Ordering;
 /// // Take the value out of the cell
 /// assert_eq!(cell.take(), Some(2047))
 /// ```
-#[derive(Debug)]
 pub struct PtrCell<T> {
     /// Pointer to the contained value
     value: core::sync::atomic::AtomicPtr<T>,
@@ -459,6 +458,16 @@ impl<T> PtrCell<T> {
             Some(value) => Box::into_raw(Box::new(value)),
             None => core::ptr::null_mut(),
         }
+    }
+}
+
+impl<T> Debug for PtrCell<T> {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        formatter
+            .debug_struct("PtrCell")
+            .field("value", &self.value)
+            .field("order", &self.order)
+            .finish()
     }
 }
 


### PR DESCRIPTION
This branch manually implements `Debug` for `PtrCell<T>` to avoid introducing the automatically generated `T: Debug` bound