### PR TITLE
Redesign the cell's usage of Semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 # Protect against accidental copies
 :w
 :
+
+# Rare, but still happens
+w

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## 2.0.0 - 4/6/24
 
+## Added
+- Links to helpful resources in the documentation for `Semantics`
+
 ## Changed
 - `PtrCell` now has the same in-memory representation as a `*mut T`
 - `PtrCell::new` doesn't require a `Semantics` variant anymore
 - `PtrCell::{is_empty, replace, take, map_owner}` now require a `Semantics` variant
+- The documentation for `Semantics::Coupled` now better reflects the reality
 
 ## 1.2.1 - 3/25/24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.0 - 4/6/24
+
+## Changed
+- `PtrCell` now has the same in-memory representation as a `*mut T`
+- `PtrCell::new` doesn't require a `Semantics` variant anymore
+- `PtrCell::{is_empty, replace, take, map_owner}` now require a `Semantics` variant
+
 ## 1.2.1 - 3/25/24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ptr_cell"
-version = "1.2.1"
+version = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptr_cell"
-version = "1.2.1"
+version = "2.0.0"
 authors = ["Nikolay Levkovsky <nik@nous.so>"]
 edition = "2021"
 description = "Thread-safe cell based on atomic pointers to externally stored data"

--- a/README.md
+++ b/README.md
@@ -37,17 +37,19 @@ This will add `ptr_cell` to your Cargo.toml file, allowing you to use it in your
 ## Usage
 
 ```rust
-// Construct a new cell with default coupled semantics
+use ptr_cell::Semantics;
+
+// Construct a cell
 let cell: ptr_cell::PtrCell<u16> = 0x81D.into();
 
 // Replace the value inside the cell
-assert_eq!(cell.replace(Some(2047)), Some(0x81D));
+assert_eq!(cell.replace(Some(2047), Semantics::Relaxed), Some(0x81D));
 
 // Check whether the cell is empty
-assert_eq!(cell.is_empty(), false);
+assert_eq!(cell.is_empty(Semantics::Relaxed), false);
 
 // Take the value out of the cell
-assert_eq!(cell.take(), Some(2047))
+assert_eq!(cell.take(Semantics::Relaxed), Some(2047))
 ```
 
 ## Semantics
@@ -75,7 +77,7 @@ fn main() {
     const VALUES: [u8; 11] = [47, 12, 88, 45, 67, 34, 78, 90, 11, 77, 33];
 
     // Construct a cell to hold the current maximum value
-    let cell = ptr_cell::PtrCell::new(None, ptr_cell::Semantics::Relaxed);
+    let cell = ptr_cell::PtrCell::new(None);
     let maximum = std::sync::Arc::new(cell);
 
     // Slice the array in two
@@ -118,7 +120,7 @@ where
         // Try to insert the value into the cell
         loop {
             // Replace the cell's value
-            let previous = buffer.replace(slot);
+            let previous = buffer.replace(slot, ptr_cell::Semantics::Relaxed);
 
             // Determine whether the swap resulted in a decrease of the buffer's value
             match slot < previous {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,17 +19,19 @@
 //! ## Usage
 //!
 //! ```rust
-//! // Construct a new cell with default coupled semantics
+//! use ptr_cell::Semantics;
+//!
+//! // Construct a cell
 //! let cell: ptr_cell::PtrCell<u16> = 0x81D.into();
 //!
 //! // Replace the value inside the cell
-//! assert_eq!(cell.replace(Some(2047)), Some(0x81D));
+//! assert_eq!(cell.replace(Some(2047), Semantics::Relaxed), Some(0x81D));
 //!
 //! // Check whether the cell is empty
-//! assert_eq!(cell.is_empty(), false);
+//! assert_eq!(cell.is_empty(Semantics::Relaxed), false);
 //!
 //! // Take the value out of the cell
-//! assert_eq!(cell.take(), Some(2047))
+//! assert_eq!(cell.take(Semantics::Relaxed), Some(2047))
 //! ```
 //!
 //! ## Semantics
@@ -53,12 +55,14 @@
 //! sequence's halves
 //!
 //! ```rust
+//! use ptr_cell::Semantics;
+//!
 //! fn main() {
 //!     // Initialize an array of random numbers
 //!     const VALUES: [u8; 11] = [47, 12, 88, 45, 67, 34, 78, 90, 11, 77, 33];
 //!
 //!     // Construct a cell to hold the current maximum value
-//!     let cell = ptr_cell::PtrCell::new(None, ptr_cell::Semantics::Relaxed);
+//!     let cell = ptr_cell::PtrCell::new(None);
 //!     let maximum = std::sync::Arc::new(cell);
 //!
 //!     // Slice the array in two
@@ -83,7 +87,7 @@
 //!     }
 //!
 //!     // Check the found maximum
-//!     assert_eq!(maximum.take(), Some(90))
+//!     assert_eq!(maximum.take(Semantics::Relaxed), Some(90))
 //! }
 //!
 //! /// Inserts the maximum of `sequence` and `buffer` into `buffer`
@@ -101,7 +105,7 @@
 //!         // Try to insert the value into the cell
 //!         loop {
 //!             // Replace the cell's value
-//!             let previous = buffer.replace(slot);
+//!             let previous = buffer.replace(slot, Semantics::Relaxed);
 //!
 //!             // Determine whether the swap resulted in a decrease of the buffer's value
 //!             match slot < previous {
@@ -141,26 +145,29 @@ use core::sync::atomic::Ordering;
 /// to *leaked* values allocated by [`Box`]. Synchronization is achieved by atomically manipulating
 /// these pointers
 ///
+/// This type has the same in-memory representation as a `*mut T`
+///
 /// # Usage
 ///
 /// ```rust
-/// // Construct a new cell with default coupled semantics
+/// use ptr_cell::Semantics;
+///
+/// // Construct a cell
 /// let cell: ptr_cell::PtrCell<u16> = 0x81D.into();
 ///
 /// // Replace the value inside the cell
-/// assert_eq!(cell.replace(Some(2047)), Some(0x81D));
+/// assert_eq!(cell.replace(Some(2047), Semantics::Relaxed), Some(0x81D));
 ///
 /// // Check whether the cell is empty
-/// assert_eq!(cell.is_empty(), false);
+/// assert_eq!(cell.is_empty(Semantics::Relaxed), false);
 ///
 /// // Take the value out of the cell
-/// assert_eq!(cell.take(), Some(2047))
+/// assert_eq!(cell.take(Semantics::Relaxed), Some(2047))
 /// ```
+#[repr(transparent)]
 pub struct PtrCell<T> {
     /// Pointer to the contained value
     value: core::sync::atomic::AtomicPtr<T>,
-    /// Group of memory orderings for internal atomic operations
-    order: Semantics,
 }
 
 impl<T> PtrCell<T> {
@@ -169,6 +176,8 @@ impl<T> PtrCell<T> {
     /// # Usage
     ///
     /// ```rust
+    /// use ptr_cell::Semantics;
+    ///
     /// // Construct a cell with a String inside
     /// let mut text: ptr_cell::PtrCell<_> = "Punto aquí".to_string().into();
     ///
@@ -179,13 +188,13 @@ impl<T> PtrCell<T> {
     ///
     /// // Check the String's value
     /// let sentence = "Punto aquí con un puntero".to_string();
-    /// assert_eq!(text.take(), Some(sentence))
+    /// assert_eq!(text.take(Semantics::Relaxed), Some(sentence))
     /// ```
     #[inline(always)]
     pub fn get_mut(&mut self) -> Option<&mut T> {
-        let leaked = self.value.load(self.order.read());
+        let leak = *self.value.get_mut();
 
-        non_null(leaked).map(|ptr| unsafe { &mut *ptr })
+        non_null(leak).map(|ptr| unsafe { &mut *ptr })
     }
 
     /// Replaces the cell's value with a new one, constructed from the cell itself using the
@@ -198,6 +207,8 @@ impl<T> PtrCell<T> {
     ///
     /// ```rust
     /// fn main() {
+    ///     use ptr_cell::Semantics;
+    ///
     ///     // Initialize a sample sentence
     ///     const SENTENCE: &str = "Hachó en México";
     ///
@@ -210,19 +221,19 @@ impl<T> PtrCell<T> {
     ///         let value = word;
     ///
     ///         // Replace the node with a new one pointing to it
-    ///         cell.map_owner(|next| Node { value, next });
+    ///         cell.map_owner(|next| Node { value, next }, Semantics::Relaxed);
     ///     }
     ///
     ///     // Take the first node out of the cell and destructure it
     ///     let Node { value, mut next } = cell
-    ///         .take()
+    ///         .take(Semantics::Relaxed)
     ///         .expect("Values should have been inserted into the cell");
     ///
     ///     // Initialize the "decoded" sentence with the first word
     ///     let mut decoded = value.to_string();
     ///
     ///     // Iterate over each remaining node
-    ///     while let Some(node) = next.take() {
+    ///     while let Some(node) = next.take(Semantics::Relaxed) {
     ///         // Append the word to the sentence
     ///         decoded += " ";
     ///         decoded += node.value;
@@ -246,13 +257,13 @@ impl<T> PtrCell<T> {
     ///     }
     /// }
     /// ```
-    pub fn map_owner<F>(&self, new: F)
+    pub fn map_owner<F>(&self, new: F, order: Semantics)
     where
         F: FnOnce(Self) -> T,
         T: AsMut<Self>,
     {
-        let value_ptr = self.value.load(self.order.read());
-        let value = unsafe { Self::from_ptr(value_ptr, self.order) };
+        let value_ptr = self.value.load(order.read());
+        let value = unsafe { Self::from_ptr(value_ptr) };
 
         let owner_slot = Some(new(value));
         let owner_ptr = Self::heap_leak(owner_slot);
@@ -264,8 +275,8 @@ impl<T> PtrCell<T> {
             let value_ptr_result = self.value.compare_exchange_weak(
                 *value_ptr,
                 owner_ptr,
-                self.order.read_write(),
-                self.order.read(),
+                order.read_write(),
+                order.read(),
             );
 
             match value_ptr_result {
@@ -277,27 +288,28 @@ impl<T> PtrCell<T> {
 
     /// Returns the cell's value, leaving [`None`] in its place
     ///
-    /// This is an alias for `self.replace(None)`
+    /// This is an alias for `self.replace(None, order)`
     ///
     /// # Usage
     ///
     /// ```rust
+    /// use ptr_cell::Semantics;
+    ///
     /// // Initialize a sample number
     /// const VALUE: Option<u8> = Some(0b01000101);
     ///
     /// // Wrap the number in a cell
-    /// let ordered = ptr_cell::Semantics::Ordered;
-    /// let cell = ptr_cell::PtrCell::new(VALUE, ordered);
+    /// let cell = ptr_cell::PtrCell::new(VALUE);
     ///
     /// // Take the number out
-    /// assert_eq!(cell.take(), VALUE);
+    /// assert_eq!(cell.take(Semantics::Relaxed), VALUE);
     ///
     /// // Verify that the cell is now empty
-    /// assert_eq!(cell.take(), None)
+    /// assert_eq!(cell.take(Semantics::Relaxed), None)
     /// ```
     #[inline(always)]
-    pub fn take(&self) -> Option<T> {
-        self.replace(None)
+    pub fn take(&self, order: Semantics) -> Option<T> {
+        self.replace(None, order)
     }
 
     /// Returns the cell's value, replacing it with `slot`
@@ -305,26 +317,26 @@ impl<T> PtrCell<T> {
     /// # Usage
     ///
     /// ```rust
+    /// use ptr_cell::Semantics;
+    ///
     /// // Construct an empty cell
-    /// let cell = ptr_cell::PtrCell::new(None, Default::default());
+    /// let cell = ptr_cell::PtrCell::default();
     ///
     /// // Initialize a pair of values
     /// let odd = Some(vec![1, 3, 5]);
     /// let even = Some(vec![2, 4, 6]);
     ///
     /// // Replace the value multiple times
-    /// assert_eq!(cell.replace(odd.clone()), None);
-    /// assert_eq!(cell.replace(even.clone()), odd);
-    /// assert_eq!(cell.replace(None), even)
+    /// assert_eq!(cell.replace(odd.clone(), Semantics::Relaxed), None);
+    /// assert_eq!(cell.replace(even.clone(), Semantics::Relaxed), odd);
+    /// assert_eq!(cell.replace(None, Semantics::Relaxed), even)
     /// ```
     #[inline(always)]
-    pub fn replace(&self, slot: Option<T>) -> Option<T> {
-        let read_write = self.order.read_write();
+    pub fn replace(&self, slot: Option<T>, order: Semantics) -> Option<T> {
+        let new_leak = Self::heap_leak(slot);
+        let old_leak = self.value.swap(new_leak, order.read_write());
 
-        let new_leaked = Self::heap_leak(slot);
-        let old_leaked = self.value.swap(new_leaked, read_write);
-
-        non_null(old_leaked).map(|ptr| *unsafe { Box::from_raw(ptr) })
+        unsafe { Self::heap_reclaim(old_leak) }
     }
 
     /// Determines whether this cell is empty
@@ -332,46 +344,47 @@ impl<T> PtrCell<T> {
     /// # Usage
     ///
     /// ```rust
-    /// use ptr_cell::PtrCell;
+    /// use ptr_cell::Semantics;
     /// use std::collections::HashMap;
     ///
     /// // Construct an empty cell
-    /// let cell: PtrCell<HashMap<u16, String>> = PtrCell::default();
+    /// let cell: ptr_cell::PtrCell<HashMap<u16, String>> = Default::default();
     ///
-    /// // The cell's default value is None (empty)
-    /// assert!(cell.is_empty(), "The cell should be empty by default")
+    /// // Check that the cell's default value is None (empty)
+    /// assert!(
+    ///     cell.is_empty(Semantics::Relaxed),
+    ///     "The cell should be empty by default"
+    /// )
     /// ```
     #[inline(always)]
-    pub fn is_empty(&self) -> bool {
-        let read = self.order.read();
-
-        self.value.load(read).is_null()
+    pub fn is_empty(&self, order: Semantics) -> bool {
+        self.value.load(order.read()).is_null()
     }
 
-    /// Constructs a cell with `slot` inside and `order` as its memory ordering
+    /// Constructs a cell with `slot` inside
     ///
     /// # Usage
     ///
     /// ```rust
+    /// use ptr_cell::Semantics;
+    ///
     /// // Initialize a sample number
     /// const VALUE: Option<u16> = Some(0xFAA);
     ///
     /// // Wrap the number in a cell
-    /// let ordered = ptr_cell::Semantics::Ordered;
-    /// let cell = ptr_cell::PtrCell::new(VALUE, ordered);
+    /// let cell = ptr_cell::PtrCell::new(VALUE);
     ///
     /// // Take the number out
-    /// assert_eq!(cell.take(), VALUE)
+    /// assert_eq!(cell.take(Semantics::Relaxed), VALUE)
     /// ```
     #[inline(always)]
-    pub fn new(slot: Option<T>, order: Semantics) -> Self {
+    pub fn new(slot: Option<T>) -> Self {
         let ptr = Self::heap_leak(slot);
 
-        unsafe { Self::from_ptr(ptr, order) }
+        unsafe { Self::from_ptr(ptr) }
     }
 
-    /// Constructs a cell that owns the allocation to which `ptr` points. The cell will use `order`
-    /// as its memory ordering
+    /// Constructs a cell that owns the allocation to which `ptr` points
     ///
     /// Passing in a null `ptr` is perfectly valid, as it represents [`None`]. Conversely, a
     /// non-null `ptr` is treated as [`Some`]
@@ -385,6 +398,8 @@ impl<T> PtrCell<T> {
     /// # Usage
     ///
     /// ```rust, ignore
+    /// use ptr_cell::Semantics;
+    ///
     /// // Initialize a sample number
     /// const VALUE: Option<u16> = Some(0xFAA);
     ///
@@ -392,66 +407,46 @@ impl<T> PtrCell<T> {
     /// let value_ptr = ptr_cell::PtrCell::heap_leak(VALUE);
     ///
     /// // Construct a cell from the pointer
-    /// let ordered = ptr_cell::Semantics::Ordered;
-    /// let cell = unsafe { ptr_cell::PtrCell::from_ptr(value_ptr, ordered) };
+    /// let cell = unsafe { ptr_cell::PtrCell::from_ptr(value_ptr) };
     ///
     /// // Take the number out
-    /// assert_eq!(cell.take(), VALUE)
+    /// assert_eq!(cell.take(Semantics::Relaxed), VALUE)
     /// ```
     ///
     /// [1]: https://doc.rust-lang.org/std/boxed/index.html#memory-layout
     #[inline(always)]
-    const unsafe fn from_ptr(ptr: *mut T, order: Semantics) -> Self {
+    const unsafe fn from_ptr(ptr: *mut T) -> Self {
         let value = core::sync::atomic::AtomicPtr::new(ptr);
 
-        Self { value, order }
+        Self { value }
     }
 
-    /// Sets the memory ordering of this cell to `order`
+    /// Reclaims ownership of the memory pointed to by `ptr` and returns the contained value
     ///
-    /// # Usage
+    /// **A null pointer represents [None]**
     ///
-    /// ```rust
-    /// use ptr_cell::{PtrCell, Semantics};
+    /// This function is intended to be the inverse of [`heap_leak`](Self::heap_leak)
     ///
-    /// // Construct a cell with relaxed semantics
-    /// let mut cell: PtrCell<Vec<u8>> = PtrCell::new(None, Semantics::Relaxed);
+    /// # Safety
     ///
-    /// // Change the semantics to coupled
-    /// cell.set_order(Semantics::Coupled);
+    /// If `ptr` is non-null, the memory it points to must have been allocated in accordance with
+    /// the [memory layout][1] used by [`Box`]
     ///
-    /// // Check the updated semantics
-    /// assert_eq!(cell.get_order(), Semantics::Coupled)
-    /// ```
+    /// Dereferencing `ptr` after this function has been called is undefined behavior
+    ///
+    /// [1]: https://doc.rust-lang.org/std/boxed/index.html#memory-layout
     #[inline(always)]
-    pub fn set_order(&mut self, order: Semantics) {
-        self.order = order
+    unsafe fn heap_reclaim(ptr: *mut T) -> Option<T> {
+        non_null(ptr).map(|ptr| *Box::from_raw(ptr))
     }
 
-    /// Returns the current memory ordering of this cell
+    /// Leaks `slot` to the heap and returns a raw pointer to it
     ///
-    /// # Usage
+    /// **[None] is represented by a null pointer**
     ///
-    /// ```rust
-    /// use ptr_cell::PtrCell;
+    /// The memory will be allocated in accordance with the [memory layout][1] used by [`Box`]
     ///
-    /// // Construct a cell with relaxed semantics
-    /// let relaxed = ptr_cell::Semantics::Relaxed;
-    /// let cell: PtrCell<String> = PtrCell::new(None, relaxed);
-    ///
-    /// // Check the cell's semantics
-    /// assert_eq!(cell.get_order(), relaxed)
-    /// ```
-    #[inline(always)]
-    pub fn get_order(&self) -> Semantics {
-        self.order
-    }
-
-    /// Returns a raw pointer to the value contained within `slot`
-    ///
-    /// Works differently depending on the `slot`'s variant:
-    /// - [`Some(T)`]: allocates `T` on the heap using [`Box`] and leaks it
-    /// - [`None`]: creates a null pointer
+    /// [1]: https://doc.rust-lang.org/std/boxed/index.html#memory-layout
     #[inline(always)]
     fn heap_leak(slot: Option<T>) -> *mut T {
         match slot {
@@ -466,30 +461,31 @@ impl<T> core::fmt::Debug for PtrCell<T> {
         formatter
             .debug_struct("PtrCell")
             .field("value", &self.value)
-            .field("order", &self.order)
             .finish()
     }
 }
 
 impl<T> Default for PtrCell<T> {
-    /// Constructs an empty cell with the memory ordering of [`Coupled`](Semantics::Coupled)
+    /// Constructs an empty cell
     #[inline(always)]
     fn default() -> Self {
-        Self::new(None, Default::default())
+        Self::new(None)
     }
 }
 
 impl<T> Drop for PtrCell<T> {
     #[inline(always)]
     fn drop(&mut self) {
-        let _drop = self.take();
+        let ptr = *self.value.get_mut();
+
+        let _drop = unsafe { Self::heap_reclaim(ptr) };
     }
 }
 
 impl<T> From<T> for PtrCell<T> {
     #[inline(always)]
     fn from(value: T) -> Self {
-        Self::new(Some(value), Default::default())
+        Self::new(Some(value))
     }
 }
 


### PR DESCRIPTION
Requiring the cell to have default Semantics was an obvious mistake in the API. It was done this way because I've overlooked the fact that Drop::drop requires exclusive access (&mut self)

This branch fixes this by making the accessors take a variant of Semantics. It also makes the documentation a bit nicer and, in the case of Semantics, more beginner-friendly