### PR TITLE
Use the correct crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ptr_cell"
-version = "2.1.0"
+version = "2.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptr_cell"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Nikolay Levkovsky <nik@nous.so>"]
 edition = "2021"
 description = "Thread-safe cell based on atomic pointers to externally stored data"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Alternatively, you can do this by manually adding the following lines to the fil
 
 ```toml
 [dependencies.ptr_cell]
-version = "2.0.0"
+version = "2.1.1"
 ```
 
 ## Usage


### PR DESCRIPTION
I forgot to update it in the manual installation guide from [README.md](README.md)