### PR TITLE
Implement some missing methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ target/
 
 # Protect against accidental copies
 :w
-:
-
-# Rare, but still happens
+;w
 w
+:
+;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.2.0 - 4/14/24
+
+### Added
+- `PtrCell::swap`: Method for swapping the values of two cells
+- `PtrCell::{set, set_ptr}`: Methods for overwriting the cell's value
+- A section discussing the pointer API of `PtrCell` to the cell's documentation
+- A note on the safety of `PtrCell::replace_ptr`
+
+### Changed
+- Clarified the purpose of `PtrCell::map_owner` a bit
+
+## 2.1.1 - 4/10/24
+
+### Changed
+- Used the correct version number in README.md
+
 ## 2.1.0 - 4/10/24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ## 2.0.0 - 4/6/24
 
+![will it affect me? yes][yes]
+
 ### Added
 - Links to helpful resources in the documentation for `Semantics`
 
@@ -52,3 +54,6 @@
 ### Added
 - `PtrCell`: Thread-safe cell based on atomic pointers
 - `Semantics`: Memory ordering semantics for `PtrCell`'s atomic operations
+
+<!-- References -->
+[yes]: https://img.shields.io/badge/will%20it%20affect%20me%3F-yes-red.svg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "ptr_cell"
-version = "2.1.1"
+version = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptr_cell"
-version = "2.1.1"
+version = "2.2.0"
 authors = ["Nikolay Levkovsky <nik@nous.so>"]
 edition = "2021"
 description = "Thread-safe cell based on atomic pointers to externally stored data"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Alternatively, you can do this by manually adding the following lines to the fil
 
 ```toml
 [dependencies.ptr_cell]
-version = "2.1.1"
+version = "2.2.0"
 ```
 
 ## Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,6 +343,65 @@ impl<T> PtrCell<T> {
         self.replace_ptr(core::ptr::null_mut(), order)
     }
 
+    /// Sets the cell's value to `slot`
+    ///
+    /// This is an alias for `{ self.replace(slot, order); }`
+    ///
+    /// # Usage
+    ///
+    /// ```rust
+    /// use ptr_cell::Semantics;
+    ///
+    /// // Initialize a test value
+    /// const VALUE: Option<u16> = Some(1776);
+    ///
+    /// // Construct an empty cell
+    /// let cell: ptr_cell::PtrCell<_> = Default::default();
+    ///
+    /// // Set the cell's value
+    /// cell.set(VALUE, Semantics::Relaxed);
+    ///
+    /// // Check that the value was set
+    /// assert_eq!(cell.take(Semantics::Relaxed), VALUE)
+    /// ```
+    #[inline(always)]
+    pub fn set(&self, slot: Option<T>, order: Semantics) {
+        self.replace(slot, order);
+    }
+
+    /// Sets the pointer to the cell's value to `ptr`
+    ///
+    /// # Safety
+    ///
+    /// The memory `ptr` points to must conform to the [memory layout][1] used by [`Box`]
+    ///
+    /// # Usage
+    ///
+    /// ```rust
+    /// use ptr_cell::Semantics;
+    ///
+    /// // Initialize a test value
+    /// const VALUE: Option<u16> = Some(1776);
+    ///
+    /// // Construct an empty cell
+    /// let cell: ptr_cell::PtrCell<_> = Default::default();
+    ///
+    /// // Allocate the value and get a pointer to it
+    /// let ptr = ptr_cell::PtrCell::heap_leak(VALUE);
+    ///
+    /// // Make the cell point to the allocation
+    /// unsafe { cell.set_ptr(ptr, Semantics::Relaxed) };
+    ///
+    /// // Check that the value was set
+    /// assert_eq!(cell.take(Semantics::Relaxed), VALUE)
+    /// ```
+    ///
+    /// [1]: https://doc.rust-lang.org/std/boxed/index.html#memory-layout
+    #[inline(always)]
+    pub unsafe fn set_ptr(&self, ptr: *mut T, order: Semantics) {
+        self.value.store(ptr, order.write())
+    }
+
     /// Returns the cell's value, replacing it with `slot`
     ///
     /// # Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,36 @@ impl<T> PtrCell<T> {
         }
     }
 
+    /// Swaps the values of two cells
+    ///
+    /// # Usage
+    ///
+    /// ```rust
+    /// use ptr_cell::Semantics;
+    ///
+    /// // Initialize a pair of test values
+    /// const ONE: Option<u8> = Some(1);
+    /// const TWO: Option<u8> = Some(2);
+    ///
+    /// // Construct a cell from each value
+    /// let cell_one = ptr_cell::PtrCell::new(ONE);
+    /// let mut cell_two = ptr_cell::PtrCell::new(TWO);
+    ///
+    /// // Swap the cells' contents
+    /// cell_one.swap(&mut cell_two, Semantics::Relaxed);
+    ///
+    /// // Check that the cells now contain each other's values
+    /// assert_eq!(ONE, cell_two.take(Semantics::Relaxed));
+    /// assert_eq!(TWO, cell_one.take(Semantics::Relaxed))
+    /// ```
+    #[inline(always)]
+    pub fn swap(&self, other: &mut Self, order: Semantics) {
+        let other_ptr = other.get_ptr(Semantics::Relaxed);
+
+        let ptr = self.replace_ptr(other_ptr, order);
+        unsafe { other.set_ptr(ptr, Semantics::Relaxed) }
+    }
+
     /// Returns the cell's value, replacing it with [`None`]
     ///
     /// This is an alias for `self.replace(None, order)`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,8 +204,7 @@ impl<T> PtrCell<T> {
     /// Replaces the cell's value with a new one, constructed from the cell itself using the
     /// provided `new` function
     ///
-    /// Despite the fact that this operation is somewhat complex, it's still entirely atomic. This
-    /// allows it to be safely used in implementations of shared linked-list-like data structures
+    /// Think of this like the `push` method for a linked list, where each node is a `PtrCell`
     ///
     /// # Usage
     ///


### PR DESCRIPTION
This branch adds methods `set`, `set_ptr`, and `swap` to `PtrCell`. It also clarifies the unsafe part of the cell's API a bit