### PR TITLE
Make minor tweaks to publish the latest update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 3.0.0 - TBD
+## 2.2.1 - 6/17/24
 
 ### Changed
-- The _entire_ documentation
+- Overhauled the _entire_ documentation
+- PtrCell::{heap_leak, new, replace_ptr, replace} were annotated with `must_use` to prevent bugs
 
 ## 2.2.0 - 4/14/24
 
@@ -11,15 +12,15 @@
 - `PtrCell::swap`: Method for swapping the values of two cells
 - `PtrCell::{set, set_ptr}`: Methods for overwriting the cell's value
 - A section discussing the pointer API of `PtrCell` in the cell's documentation
-- A warning regarding the safety of `PtrCell::replace_ptr`
+- A warning about the safety of `PtrCell::replace_ptr`
 
 ### Changed
-- The documentation of `PtrCell::map_owner`
+- Updated the documentation of `PtrCell::map_owner`
 
 ## 2.1.1 - 4/10/24
 
 ### Fixed
-- The version number in README.md
+- README now contains the correct version number
 
 ## 2.1.0 - 4/10/24
 
@@ -32,10 +33,10 @@
 - Comments in the usage of `Semantics::{read, read_write, write}`
 
 ### Changed
-- The examples of `PtrCell::{is_empty, replace}`
+- `PtrCell::{is_empty, replace}` got better examples
 
 ### Fixed
-- Broken links in the documentation
+- Fixed broken links in the documentation
 
 ## 2.0.0 - 4/6/24
 
@@ -50,12 +51,12 @@
 - `PtrCell::{is_empty, replace, take, map_owner}` now require a `Semantics` variant
 
 ### Fixed
-- The documentation for `Semantics::Coupled`
+- The documentation for `Semantics::Coupled` is now closer to reality
 
 ## 1.2.1 - 3/25/24
 
 ### Fixed
-- The unnecessary `T: Debug` bound in `PtrCell`'s `Debug` implementation
+- Removed the unnecessary `T: Debug` bound in `PtrCell`'s `Debug` implementation
 
 ## 1.2.0 - 3/24/24
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,11 @@
 Thank you for your interest in contributing to this project! The maintainers would be more than
 happy to review and merge your pull requests
 
+Need an idea? Search for comments at the top of [lib.rs](src/lib.rs). Some are often left there to
+document missing features, suggest how they could be implemented, or as a crude roadmap
+
 By contributing, you agree that all submitted work will be licensed under the terms of CC0 1.0. For
-more information on how your contributions are licensed, please refer to [LICENSE.md](#LICENSE.md)
+more information on how your contributions are licensed, please refer to [LICENSE.md](LICENSE.md)
 
 **Note:** If you're unable or unwilling to agree to these terms, you may choose to fork the project
 instead
@@ -14,23 +17,23 @@ instead
 We follow a branch naming convention for more clarity and order in the version control history.
 Please use the following prefixes when creating branches:
 
-- **`feature/`:** New features or major enhancements
-  Example: `feature/more-tags`
+- **`feature/`:** New features or major enhancements<br>
+  <sub>Example: `feature/more-tags`</sub>
 
-- **`fix/`:** Bug fixes or issue resolution
-  Example: `fix/memory-leak`
+- **`fix/`:** Bug fixes or issue resolution<br>
+  <sub>Example: `fix/memory-leak`</sub>
 
-- **`hotfix/`:** Like **`fix/`**, but when something went *REALLY WRONG*
-  Example: `hotfix/security-patch`
+- **`hotfix/`:** Like **`fix/`**, but when something went *REALLY WRONG*<br>
+  <sub>Example: `hotfix/security-patch`</sub>
 
-- **`doc/`:** Documentation updates
-  Example: `doc/update-readme`
+- **`doc/`:** Documentation updates<br>
+  <sub>Example: `doc/update-readme`</sub>
 
-- **`test/`:** Test infrastructure updates
-  Example: `test/add-unit-tests`
+- **`test/`:** Test infrastructure updates<br>
+  <sub>Example: `test/add-unit-tests`</sub>
 
-- **`chore/`:** Routine tasks or maintenance
-  Example: `chore/update-dependencies`
+- **`chore/`:** Routine tasks or maintenance<br>
+  <sub>Example: `chore/update-dependencies`</sub>
 
-- **`misc/`:** Updates that don't fall under any other category
-  Example: `misc/new-branding`
+- **`misc/`:** Updates that don't fall under any other category<br>
+  <sub>Example: `misc/new-branding`</sub>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ repository = "https://github.com/KDFJW/ptr_cell"
 license = "CC0-1.0"
 keywords = ["thread-safe", "atomic", "cell", "no_std"]
 categories = ["memory-management", "data-structures", "concurrency", "no-std"]
-
-[features]
-std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "ptr_cell"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Nikolay Levkovsky <nik@nous.so>"]
 edition = "2021"
-description = "Thread-safe cell based on atomic pointers to externally stored data"
+description = "Thread-safe cell based on atomic pointers"
 readme = "README.md"
 repository = "https://github.com/KDFJW/ptr_cell"
-license = "CC0-1.0 OR Apache-2.0"
+license = "CC0-1.0"
 keywords = ["thread-safe", "atomic", "cell", "no_std"]
 categories = ["memory-management", "data-structures", "concurrency", "no-std"]
+
+[features]
+std = []

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Simple thread-safe cell
+# Simple thread-safe cell for Rust
 
 [`PtrCell`][1] is an atomic cell type that allows safe, concurrent access to shared data. No
 [`std`][2], no data races, no [nasal demons][3] (undefined behavior), and most importantly, no locks
@@ -8,12 +8,19 @@ of it. If you want to concurrently update a value through mutable references and
 support for `no_std`, take a look at the standard [`Mutex`][4] and [`RwLock`][5] instead
 
 #### Offers:
-- **Ease of use**: The API is fairly straightforward
-- **Performance**: All algorithms are at most a couple of instructions long
 
-#### Limits:
-- **Access**: To see what's stored inside a cell, you must either take the value out of it or
-provide exclusive access (`&mut`) to the cell
+- **Familiarity**: `PtrCell`'s API was modelled after `std`'s [Cell](core::cell::Cell)
+
+- **Easy Concurrency**: No more `Arc<Mutex<T>>`, `Arc::clone()`, and `Mutex::lock().expect()`! Leave
+the data static and then point to it when you need to. It's a _single instruction_ on most modern
+platforms
+
+#### Limitations:
+
+- **Heap Allocation**: Every value you insert into `PtrCell` must first be allocated using [`Box`].
+Allocating on the heap is, computationally, a moderately expensive operation. To address this, the
+cell exposes a pointer API that can be used to avoid allocating the same values multiple times.
+Future releases will primarily rely on the stack
 
 ## Table of Contents
 - [Installation](#installation)
@@ -115,6 +122,8 @@ where
 ## Contributing
 
 Yes, please! See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+Authors of merged pull requests will be rewarded with snacks
 
 ## License
 


### PR DESCRIPTION
Changes committed in the "documentation overhaul" branch were meant to be published together with 3.0.0. However, it now seems that this major release will be delayed a bit due to the need to figure out a better layout for the cell

This branch makes some additional quality-of-life improvements. More importantly, it amends the documentation update to make it standalone